### PR TITLE
src/interface.rs: implement heap HID interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,7 @@ Batteries included embedded USB HID library for [`usb-device`](https://crates.io
 Includes Keyboard (boot and NKRO), Mouse, Joystick and Consumer Control implementations as well as
 support for building your own HID classes.
 
-Tested on the RP2040, but should work on any platform supported by
-[`usb-device`](https://crates.io/crates/usb-device).
+While most of the code is the same as [upstream](https://github.com/dlkj/usbd-human-interface-device), this crate is not `no_std` compatible anymore and its code will change according to the necessities of [`xous-core`](https://github.com/betrusted-io/xous-core/). 
 
 Devices created with this library should work with any USB host. Tested on Windows,
 Linux, MacOS and Android.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![no_std]
 #![warn(clippy::pedantic)]
 #![warn(clippy::style)]
 #![warn(clippy::cargo)]


### PR DESCRIPTION
Implement heap-allocated HID interface, allowing callers to provide a `Vec<u8>` for the report descriptor, rather than a `&[u8]`.

In order to do this, relax the `no_std` requirement, and write this down in the README.md as well.